### PR TITLE
Fix Makefile recipes and configure pip check

### DIFF
--- a/nudgepay-main/Makefile
+++ b/nudgepay-main/Makefile
@@ -7,31 +7,31 @@
 APP_DIR ?= nudgepay
 
 help:
-        @echo "Targets mirror those inside $(APP_DIR)/Makefile"
-        @echo "  make install   → install development dependencies"
-        @echo "  make lint      → run ruff lint checks"
-        @echo "  make fmt       → run formatting check"
-        @echo "  make fmt-fix   → auto-format source"
-        @echo "  make test      → execute pytest suite"
-        @echo "  make ci        → run the full CI pipeline"
+	@echo "Targets mirror those inside $(APP_DIR)/Makefile"
+	@echo "  make install   → install development dependencies"
+	@echo "  make lint      → run ruff lint checks"
+	@echo "  make fmt       → run formatting check"
+	@echo "  make fmt-fix   → auto-format source"
+	@echo "  make test      → execute pytest suite"
+	@echo "  make ci        → run the full CI pipeline"
 
 install:
-        $(MAKE) -C $(APP_DIR) install-dev
+	$(MAKE) -C $(APP_DIR) install-dev
 
 lint:
-        $(MAKE) -C $(APP_DIR) lint
+	$(MAKE) -C $(APP_DIR) lint
 
 fmt:
-        $(MAKE) -C $(APP_DIR) format
+	$(MAKE) -C $(APP_DIR) format
 
 fmt-fix:
-        $(MAKE) -C $(APP_DIR) format-fix
+	$(MAKE) -C $(APP_DIR) format-fix
 
 test:
-        $(MAKE) -C $(APP_DIR) test
+	$(MAKE) -C $(APP_DIR) test
 
 ci:
-        $(MAKE) -C $(APP_DIR) ci
+	$(MAKE) -C $(APP_DIR) ci
 
 typecheck:
-        $(MAKE) -C $(APP_DIR) typecheck
+	$(MAKE) -C $(APP_DIR) typecheck

--- a/nudgepay-main/configure
+++ b/nudgepay-main/configure
@@ -37,8 +37,13 @@ require_command() {
 
 PYTHON_BIN="${PYTHON:-python3}"
 require_command "$PYTHON_BIN"
-require_command pip3
 require_command make
+
+if ! "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+  echo "configure: missing required python module: pip" >&2
+  echo "  tried running: $PYTHON_BIN -m pip --version" >&2
+  exit 1
+fi
 
 PY_VERSION="$("$PYTHON_BIN" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')"
 REQUIRED_MAJOR=3


### PR DESCRIPTION
## Summary
- fix the root Makefile recipes so GNU make no longer errors on missing separators
- update the configure script to verify pip availability via the selected Python interpreter

## Testing
- ./configure
- make help

------
https://chatgpt.com/codex/tasks/task_e_68ddd754adac8333a2ad3eba7e4fa460