### PR TITLE
Fix GitHub Actions workflow working directory

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -8,20 +8,23 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        working-directory: nudgepay-main
+
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: configure
-      run: ./configure
+      - name: configure
+        run: ./configure
 
-    - name: Install dependencies
-      run: make
+      - name: Install dependencies
+        run: make
 
-    - name: Run check
-      run: make check
+      - name: Run check
+        run: make check
 
-    - name: Run distcheck
-      run: make distcheck
+      - name: Run distcheck
+        run: make distcheck


### PR DESCRIPTION
## Summary
- ensure the Makefile CI workflow runs from the nudgepay-main directory so ./configure and make succeed

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68de16b8d3c883339521785c2dc1edd9