### PR TITLE
Add check make target for CI workflows

### DIFF
--- a/nudgepay-main/Makefile
+++ b/nudgepay-main/Makefile
@@ -2,7 +2,7 @@
 # This keeps developer ergonomics aligned with the CI workflow defined in
 # `.github/workflows/ci.yml` which runs `make ci` from inside `nudgepay/`.
 
-.PHONY: ci install lint fmt fmt-fix test typecheck help
+.PHONY: ci install lint fmt fmt-fix test typecheck help check
 
 APP_DIR ?= nudgepay
 
@@ -13,6 +13,7 @@ help:
 	@echo "  make fmt       → run formatting check"
 	@echo "  make fmt-fix   → auto-format source"
 	@echo "  make test      → execute pytest suite"
+	@echo "  make check     → run the default CI check pipeline"
 	@echo "  make ci        → run the full CI pipeline"
 
 install:
@@ -35,3 +36,6 @@ ci:
 
 typecheck:
 	$(MAKE) -C $(APP_DIR) typecheck
+
+check:
+	$(MAKE) -C $(APP_DIR) check

--- a/nudgepay-main/nudgepay/Makefile
+++ b/nudgepay-main/nudgepay/Makefile
@@ -2,7 +2,7 @@
 SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
 
-.PHONY: run test lint format format-fix security-scan docker-build docker-up deploy-fly hash migrate backup ci release-check install-dev
+.PHONY: run test lint format format-fix security-scan docker-build docker-up deploy-fly hash migrate backup ci release-check install-dev check
 
 PYTHON ?= python3
 PIP    ?= python3 -m pip
@@ -73,4 +73,6 @@ ci:
 release-check:
 	PYTHONPATH=$$(pwd):$$(pwd)/.. ENVIRONMENT=staging python -m nudgepay.scripts.ci_validate_release
 	PYTHONPATH=$$(pwd):$$(pwd)/.. ENVIRONMENT=staging DATABASE_URL='$(DATABASE_URL)' python -m nudgepay.scripts.ci_schema_rehearsal --json
+
+check: ci
 


### PR DESCRIPTION
## Summary
- add a root-level `make check` target that mirrors the documented CI workflow
- introduce an app-level `make check` alias to execute the existing CI recipe

## Testing
- make check

------
https://chatgpt.com/codex/tasks/task_e_68de1af208d48333bcf430a6d1a6e4ad