### PR TITLE
Fix test import path for nudgepay package

### DIFF
--- a/nudgepay-main/nudgepay/__init__.py
+++ b/nudgepay-main/nudgepay/__init__.py
@@ -1,0 +1,22 @@
+"""Top-level package for the NudgePay application.
+
+This module ensures the repository can be imported as ``nudgepay`` during
+unit tests and other tooling that relies on absolute imports.
+"""
+
+from importlib import import_module
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+__all__ = ["app", "scripts"]
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in __all__:
+        return import_module(f"nudgepay.{name}")
+    raise AttributeError(f"module 'nudgepay' has no attribute {name!r}")
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from . import app as app  # type: ignore[F401]
+    from . import scripts as scripts  # type: ignore[F401]

--- a/nudgepay-main/nudgepay/tests/conftest.py
+++ b/nudgepay-main/nudgepay/tests/conftest.py
@@ -2,5 +2,9 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+PROJECT_ROOT = ROOT.parent
+
+for path in (PROJECT_ROOT, ROOT):
+    str_path = str(path)
+    if str_path not in sys.path:
+        sys.path.insert(0, str_path)


### PR DESCRIPTION
## Summary
- add a top-level `nudgepay` package so absolute imports work during testing
- extend the pytest configuration to place both the repo root and package root on `sys.path`

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de2c8744a08333b3867b156b377d9e