### PR TITLE
chore: upgrade vulnerable dependencies

### DIFF
--- a/nudgepay-main/nudgepay/requirements.txt
+++ b/nudgepay-main/nudgepay/requirements.txt
@@ -1,9 +1,9 @@
-fastapi==0.110.0
+fastapi==0.115.5
 uvicorn[standard]==0.30.0
 sqlmodel==0.0.16
 stripe==7.10.0
-jinja2==3.1.4
-python-multipart==0.0.9
+jinja2==3.1.6
+python-multipart==0.0.19
 itsdangerous==2.2.0
 bcrypt==4.2.0
 pytest==8.2.1
@@ -17,5 +17,6 @@ rq==1.16.1
 tenacity==9.0.0
 prometheus-client==0.20.0
 boto3==1.35.23
+starlette==0.47.2
 psycopg2-binary==2.9.9
 bandit==1.7.8


### PR DESCRIPTION
## Summary
- bump FastAPI, Jinja2, python-multipart, and Starlette to patched releases to resolve security scan alerts

## Testing
- Unable to install dependencies locally due to proxy restrictions

------
https://chatgpt.com/codex/tasks/task_e_68de344b3b88833387c4f39e3ab7d7ba